### PR TITLE
Update docs to reflect new service provider name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Next, add the `EnvServiceProvider` to your `providers` array in `config/app.php`
 // config/app.php
 'providers' => [
     ...
-    Sven\EnvProviders\EnvServiceProvider::class,
+    Sven\EnvProviders\ServiceProvider::class,
 ];
 ```
 


### PR DESCRIPTION
Hi @svenluijten, first off I want to say thank you for the great package I've been using it for a while now. It seems in 3.1.0 you introduced a breaking change by updating the name of the service provider from `EnvServiceProvider` to `ServiceProvider`. I discovered this when running composer update which brought my version from 3.0.1 -> 3.1.0 (following [semvar](https://semver.org/)), but immediately gave me the following error:

![missing_class](https://user-images.githubusercontent.com/7337543/56850243-cf7a6480-68cd-11e9-9a53-bcfe903ea7a9.png)

I'm not sure if you want to bump the version up to 4.0.0 to indicate the breaking change or revert the class name back or just add a tiny upgrade guide to the documentation for 3.0.1 -> 3.1.0, but this pull request at lest brings the documentation in line with the current requirement for new installs.

Thanks again for the great package.