### PR TITLE
Make compatible with Laravel 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,15 +7,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [8.0, 8.1, 8.2, 8.3]
+                php: [8.1, 8.2, 8.3]
                 dependency-version: [lowest, highest]
-                exclude:
-                    - php: 8.1
-                      dependency-version: lowest
-                    - php: 8.2
-                      dependency-version: lowest
-                    - php: 8.3
-                      dependency-version: lowest
         steps:
             - uses: actions/checkout@v4
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/support": "^8.0|^9.0"
+        "php": "^8.1",
+        "illuminate/support": "^10.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^5.5.1|^6.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         backupGlobals="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         verbose="true"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false"
 >
-    <testsuites>
-        <testsuite name="Env Providers Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+  <testsuites>
+    <testsuite name="Env Providers Test Suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This PR makes the package compatible with Laravel 10. Since the minimum PHP version of Laravel 10 is 8.1, we'll also drop support for PHP 8.0.